### PR TITLE
remove footer from calc pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ function App() {
             </Route>
             <Route exact path="/">
               <HomePage />
+              <Footer />
             </Route>
             <Route path="/calculator/:pageId">
               <CalculatorPage />
@@ -45,27 +46,33 @@ function App() {
             </Route>
             <Route exact path="/about">
               <AboutPage />
+              <Footer />
             </Route>
             <Route exact path="/contact">
               <ContactPage />
+              <Footer />
             </Route>
             <Route path="/get-involved">
               <GetInvolvedPage />
+              <Footer />
             </Route>
             <Route path="/why-vacate">
               <WhyVacatePage />
+              <Footer />
             </Route>
             <Route exact path="/resources">
               <ResourcesPage />
+              <Footer />
             </Route>
             <Route exact path="/resources/the-process">
               <TheProcessPage />
+              <Footer />
             </Route>
             <Route path="/resources/assistance">
               <AssistancePage />
+              <Footer />
             </Route>
           </Switch>
-          <Footer />
         </Box>
       </ThemeProvider>
     </div>


### PR DESCRIPTION
While working with designs for the current sprint and discussing them with Madeline we realized that it was not necessary to have the footer showing up on the calc pages (not in the SOT either), and having users focus more on the calc itself would be better, all navigation is still available through the main menu navigation.

Having the footer there was a by product of other changes to the footer I believe, so this is kind of a bug fix I think. 

Am I right about this? Let me know.