### PR TITLE
MuiLink added to Theme; links underlined for clarity

### DIFF
--- a/src/Components/Theme.jsx
+++ b/src/Components/Theme.jsx
@@ -162,6 +162,11 @@ Theme.overrides = {
             color: "white",
         },
     },
+    MuiLink: {
+        underlineHover: {
+            textDecoration: 'underline'
+        }
+    },
     MuiTabs: {
         root: {
             borderTopLeftRadius: 5,


### PR DESCRIPTION
Possible unintended consequences of Theme change noted in attached photo "186-moreDistinguishableLinks". In short, the Links in the footer are now also underlined. Let me know if this is not AC.
![186-moreDistinguishableLinks](https://user-images.githubusercontent.com/95451406/167944485-5d33b050-c42b-4d7f-9cef-96d94fc77622.png)
