### PR TITLE
added hidden button to skip navigation links -- accessibility

### DIFF
--- a/src/Components/Navigation.jsx
+++ b/src/Components/Navigation.jsx
@@ -9,6 +9,7 @@ import {
     Container,
     makeStyles,
     ButtonGroup,
+    Button
 } from "@material-ui/core";
 import { MenuSharp as MenuIcon, CloseSharp } from "@material-ui/icons";
 import pages from "../data/siteMap";
@@ -17,6 +18,7 @@ import NavButton from "../ui-kit/NavButton";
 import NavButtonMobile from "../ui-kit/NavButtonMobile";
 import LegalDisclaimer from "./LegalDisclaimer";
 import { NavigationLogo } from "./NavigationLogo";
+import SkipLink from "../ui-kit/SkipLink";
 
 const useStyles = makeStyles(theme => ({
     closeIcon: {
@@ -38,6 +40,16 @@ const useStyles = makeStyles(theme => ({
         color: "white",
         margin: theme.spacing(1),
     },
+    skipLink: {
+        marginRight: '1rem',
+        position: 'absolute',
+        transform: 'translateX(-200%)',
+        transition: 'transform 0.3s',
+        '&:focus': {
+            position: 'static',
+            transform: 'translateX(0)',
+        },
+    },
 }));
 
 const Navigation = () => {
@@ -57,6 +69,9 @@ const Navigation = () => {
             <AppBar color="primary" elevation={0}>
                 <Container maxWidth="xl">
                     <Toolbar>
+                        <SkipLink className={classes.skipLink}>
+                            <Button style={{ color: 'white' }}>Skip Navigation Links</Button>
+                        </SkipLink>
                         <NavigationLogo />
                         <Box style={{ flexGrow: 1 }} />
 

--- a/src/ui-kit/SkipLink.tsx
+++ b/src/ui-kit/SkipLink.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Container } from '@material-ui/core';
+
+interface SkipLinkProperties {
+    className?: string;
+    
+    children: React.ReactElement;
+    /**
+     * The css query aiding the selection of the
+     * container (main, section etc) we want to scroll to;
+     */
+    skipTo: string;
+}
+
+const SkipLink: React.FC<SkipLinkProperties> = props => {
+    /**
+     * On click event for sighted folks
+     * 'enter' key works as well
+     */
+    const onClick = (event: React.SyntheticEvent) => {
+        event.preventDefault();
+        /**
+         * Catch-all 'container' looking for HTML tags
+         */
+        const container: (HTMLElement | null) = document.querySelector(props.skipTo);
+        
+        /**
+         * tabIndex seems to work well with the general layout of the site
+         * Sets outline focus for screen-readers and sigthed alike
+         */
+        if (container) {
+            container.tabIndex = -1;
+            container.focus();
+            setTimeout(() => container.removeAttribute("tabindex"), 1000);
+        }
+    };
+
+    return React.cloneElement(props.children, { onClick, className: props.className });
+}
+/**
+ * skipTo set as h1 seems to work well with general layout of site
+ * Most, if not all, Subpages begin with this hiearchy
+ */
+
+SkipLink.defaultProps = {
+    className: "skipLink",
+    skipTo: "h1:first-of-type",
+};
+
+export default SkipLink;


### PR DESCRIPTION
Let me know if the Button styling doesn't quite fit. Couldn't pick between NavBar button and RedesignButtonPrimary. Of course I'm also open to other ideas, too! Any critique also welcome.

First image is a screenshot of how it looks before hitting 'tab' -- the original look of the site. A second 'tab' hides the button.
This fix was tested with Google Chrome and Google's screen reader extension.
![141-onSiteLoad](https://user-images.githubusercontent.com/95451406/168164940-3db07b4b-897e-45b9-a2c5-9a1135a577af.png)

![141-hiddenLinkAfterTab](https://user-images.githubusercontent.com/95451406/168164158-c9d1810b-b98b-4cb3-bf7d-df0cedc5a137.png)
