### PR TITLE
missing link to nwjustice.org added to /get-started, under legal aid

### DIFF
--- a/src/Pages/GetStartedPage.jsx
+++ b/src/Pages/GetStartedPage.jsx
@@ -218,7 +218,9 @@ const GetStartedPage = () => {
                 <Typography component="ul" variant="body1" className={classes.basicListStyle}>
                     <li>Outside of King County: call 1-888-201-1014 (weekdays 9.15am - 12.15pm)</li>
                     <li>In King County: call 2-1-1 (weekdays 8am - 6pm)</li>
-                    <li>You can also apply online at CLEAR*Online</li>
+                    <li>You can also apply online at
+                        {" "}<ExternalLink href="https://nwjustice.org/apply-online">CLEAR*Online</ExternalLink>{" "}
+                    </li>
                 </Typography>
 
                 <LegalAidServices />


### PR DESCRIPTION
![190-linkMissing](https://user-images.githubusercontent.com/95451406/169164311-72c98db8-a2cb-4038-8128-5a7106b3830b.png)

Perhaps a conversation we could have: should all Link components be changed to ExternalLink components? If nothing else, for that super cool arrow-through-the-box external site indicator.