### PR TITLE
graphics now all have blank alt text

### DIFF
--- a/src/Components/FactImageCard.jsx
+++ b/src/Components/FactImageCard.jsx
@@ -25,7 +25,7 @@ const FactImageCard = ({ fact }) => {
     return (
         <Card className={classes.root}>
             <Box display="flex" justifyContent="center">
-                <img className={classes.cardImageStyle} alt={fact.id} src={fact.src} />
+                <img className={classes.cardImageStyle} alt={""} src={fact.src} />
             </Box>
             <Typography variant="h5" align="center" className={classes.headingStyle}>
                 {fact.title}

--- a/src/Pages/AboutPage.jsx
+++ b/src/Pages/AboutPage.jsx
@@ -30,7 +30,7 @@ const AboutPage = () => {
                             <img
                                 src={map}
                                 className={classes.iconStyle + " " + classes.centerText}
-                                alt="person using a calculator"
+                                alt=""
                             ></img>
                         </Grid>
                     </Grid>
@@ -107,7 +107,7 @@ const AboutPage = () => {
                 <Box style={{ width: "90%", margin: "0 auto" }}>
                     <Grid container className={classes.gridStyle}>
                         <Grid item sm={12} md={6} className={classes.gridItemStyle}>
-                            <img src={checklist1} className={classes.iconStyle} alt="person using a calculator"></img>
+                            <img src={checklist1} className={classes.iconStyle} alt=""></img>
                         </Grid>
                         <Grid item sm={12} md={6} className={classes.gridItemStyle}>
                             <Typography variant="h4" className={classes.headingSpacing}>

--- a/src/Pages/GetInvolvedPage.jsx
+++ b/src/Pages/GetInvolvedPage.jsx
@@ -30,6 +30,7 @@ const GetInvolvedPage = () => {
                                 image={diversity}
                                 buttonHref="#volunteer"
                                 buttonText="volunteer"
+                                alt=""
                             />
                         </Box>
                     </Grid>
@@ -40,6 +41,7 @@ const GetInvolvedPage = () => {
                                 image={moneyJar}
                                 buttonHref="#donate"
                                 buttonText="Donate"
+                                alt=""
                             />
                         </Box>
                     </Grid>
@@ -50,6 +52,7 @@ const GetInvolvedPage = () => {
                                 image={marketing}
                                 buttonHref="#partner-with-us"
                                 buttonText="Partner with us"
+                                alt=""
                             />
                         </Box>
                     </Grid>

--- a/src/Pages/GetStartedPage.jsx
+++ b/src/Pages/GetStartedPage.jsx
@@ -59,7 +59,7 @@ const GetStartedPage = () => {
                             component="img"
                             style={{ width: "100%", padding: 16 }}
                             src={teamBuilding}
-                            alt="Teamwork solves a puzzle."
+                            alt=""
                         />
                     </Grid>
                 </Grid>

--- a/src/Pages/HomePage.jsx
+++ b/src/Pages/HomePage.jsx
@@ -40,7 +40,7 @@ const HomePage = () => {
                             <img
                                 src={calculator}
                                 className={classes.iconStyle}
-                                alt="person using a calculator      "
+                                alt=""
                             ></img>
                         </Grid>
                     </Grid>
@@ -60,19 +60,19 @@ const HomePage = () => {
             <ContentSection sectionId="how-it-works" sectionSize="lg" sectionTitle={"How It Works"}>
                 <Grid container>
                     <Grid item xs={12} sm={4}>
-                        <img className={classes.iconStyle} src={teamwork} alt={"Teamwork Icon"} />
+                        <img className={classes.iconStyle} src={teamwork} alt="" />
                         <Typography className={classes.contentTextStyle} variant="body2" align="center">
                             We break down the laws into understandable language.
                         </Typography>
                     </Grid>
                     <Grid item xs={12} sm={4}>
-                        <img className={classes.iconStyle} src={calculator} alt={"Calculator Icon"} />
+                        <img className={classes.iconStyle} src={calculator} alt="" />
                         <Typography className={classes.contentTextStyle} variant="body2" align="center">
                             You answer a few simple yes/no questions.
                         </Typography>
                     </Grid>
                     <Grid item xs={12} sm={4}>
-                        <img className={classes.iconStyle} src={checklist} alt={"Employment Icon"} />
+                        <img className={classes.iconStyle} src={checklist} alt="" />
                         <Typography className={classes.contentTextStyle} variant="body2" align="center">
                             This helps determine your vacation eligibility.
                         </Typography>
@@ -89,7 +89,7 @@ const HomePage = () => {
                 </Typography>
                 <Grid container spacing={1}>
                     <Grid item xs={12} sm={6} md={3} lg={3}>
-                        <img className={classes.iconStyle} src={city} alt={"city Icon"} />
+                        <img className={classes.iconStyle} src={city} alt="" />
                         <Typography className={classes.headingStyle} variant="h5" align="center">
                             Housing
                         </Typography>
@@ -98,7 +98,7 @@ const HomePage = () => {
                         </Typography>
                     </Grid>
                     <Grid item xs={12} sm={6} md={3} lg={3}>
-                        <img className={classes.iconStyle} src={checklist} alt={"Employment Icon"} />
+                        <img className={classes.iconStyle} src={checklist} alt="" />
                         <Typography className={classes.headingStyle} variant="h5" align="center">
                             Employment
                         </Typography>
@@ -107,7 +107,7 @@ const HomePage = () => {
                         </Typography>
                     </Grid>
                     <Grid item xs={12} sm={6} md={3} lg={3}>
-                        <img className={classes.iconStyle} src={education} alt={"Education Icon"} />
+                        <img className={classes.iconStyle} src={education} alt="" />
                         <Typography className={classes.headingStyle} variant="h5" align="center">
                             Education
                         </Typography>
@@ -116,7 +116,7 @@ const HomePage = () => {
                         </Typography>
                     </Grid>
                     <Grid item xs={12} sm={6} md={3} lg={3}>
-                        <img className={classes.iconStyle} src={lawyer} alt={"Lawyer Icon"} />
+                        <img className={classes.iconStyle} src={lawyer} alt="" />
                         <Typography className={classes.headingStyle} variant="h5" align="center">
                             Government Assistance
                         </Typography>

--- a/src/Pages/PartnerPage.jsx
+++ b/src/Pages/PartnerPage.jsx
@@ -31,7 +31,7 @@ const PartnerPage = () => {
                                 className={classes.partnerImageStyle}
                                 component="img"
                                 src={pr}
-                                alt="A person sitting on a megaphone spreading their message"
+                                alt=""
                             />
                         </Box>
                     </Grid>

--- a/src/Pages/ResourcesPage.jsx
+++ b/src/Pages/ResourcesPage.jsx
@@ -122,7 +122,7 @@ const ResourcesPage = () => {
                         </Typography>
                     </Grid>
                     <Grid item xs={12} sm={6} md={6}>
-                        <Box component="img" width="100%" src={teamBuilding} alt="Teamwork solves a puzzle." />
+                        <Box component="img" width="100%" src={teamBuilding} alt="" />
                     </Grid>
                 </Grid>
             </RedesignHeroPanel>


### PR DESCRIPTION
![195-addBlankAltTextToImg](https://user-images.githubusercontent.com/95451406/169398994-c6d25e70-e10c-495e-8250-41236d334d3a.png)
FactImageCard component received some sweeping changes, as you can see. I've scoured the site in Google Chrome with their screen reader extension, and I don't see any more or any issues. The AirTable iframes might present a bit of an issue for people who are only partially sighted, though tabbing through the page yields expected result.