### PR TITLE
197 dropdowns need aria controls

### DIFF
--- a/src/Components/FactExpandMoreCard.jsx
+++ b/src/Components/FactExpandMoreCard.jsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const FactExpandMoreCard = ({ summary, content, ariaLabel, contentID, summaryID }) => {
-    const [expanded, setExpanded] = useState();
+    const [expanded, setExpanded] = useState(false);
 
     const handleExpandClick = () => {
         setExpanded(!expanded);

--- a/src/Components/FactGroup.jsx
+++ b/src/Components/FactGroup.jsx
@@ -6,7 +6,13 @@ const FactGroup = ({ facts }) => {
         <Grid container>
             {facts.map(fact => (
                 <Grid key={fact.id} item xs={12} sm={6} md={4}>
-                    <FactExpandMoreCard summary={fact.summary} content={fact.content} />
+                    <FactExpandMoreCard
+                        summary={fact.summary}
+                        content={fact.content}
+                        ariaLabel={fact.ariaLabel}
+                        contentID={fact.contentID}
+                        summaryID={fact.summaryID}
+                    />
                 </Grid>
             ))}
         </Grid>


### PR DESCRIPTION
@sjpaige  walked me through the correct way to solve this bug, which I appreciate very much. I also noticed that the ChromeVox screen reader wasn't picking up that [FactExpandMoreCard](https://github.com/openseattle/clearviction/blob/staging/src/Components/FactExpandMoreCard.jsx) useState expanded property until the initial state was defined, so I added a default value of 'false'. This worked on my end, but if this was an over-reach on my behalf, I apologize and will remove that change.