### PR TITLE
added component=h1 to all calculator titles, fixed broken link, and spelling error

### DIFF
--- a/src/Pages/Calculator/EndScreen.jsx
+++ b/src/Pages/Calculator/EndScreen.jsx
@@ -21,7 +21,7 @@ const EndScreen = props => {
             <Grid container className={classes.backButton}>
                 <BackButton />
             </Grid>
-            <Typography variant="h5" className={classes.header}>
+            <Typography variant="h5" component="h1" className={classes.header}>
                 {props.header}
             </Typography>
             <Grid item className={classes.bodyGrid}>

--- a/src/Pages/Calculator/MainBranchTitle.jsx
+++ b/src/Pages/Calculator/MainBranchTitle.jsx
@@ -16,7 +16,7 @@ const MainBranchTitle = props => {
                 </Grid>
             )}
 
-            <Typography variant="h4" className={classes.header}>
+            <Typography variant="h4" component="h1" className={classes.header}>
                 {props.header}
             </Typography>
             {props.body && (

--- a/src/Pages/Calculator/QuestionScreen.jsx
+++ b/src/Pages/Calculator/QuestionScreen.jsx
@@ -33,7 +33,7 @@ const QuestionScreen = props => {
             <Grid container className={classes.backButton}>
                 <BackButton />
             </Grid>
-            <Typography variant="h6" className={classes.header}>
+            <Typography variant="h6" component="h1" className={classes.header}>
                 {props.header}
             </Typography>
             <Grid item className={classes.bodyGrid}>

--- a/src/Pages/Calculator/QuickStartGuide.jsx
+++ b/src/Pages/Calculator/QuickStartGuide.jsx
@@ -31,7 +31,7 @@ const QuickStartGuide = props => {
             <Grid container className={classes.backButton}>
                 <BackButton />
             </Grid>
-            <Typography variant="h4" className={classes.header}>
+            <Typography variant="h4" component="h1" className={classes.header}>
                 {props.header}
             </Typography>
             <Grid item className={classes.bodyGrid}>

--- a/src/Pages/Calculator/SpecialCaseTitle.jsx
+++ b/src/Pages/Calculator/SpecialCaseTitle.jsx
@@ -11,7 +11,7 @@ const SpecialCaseTitle = props => {
             <Grid container className={classes.backButton}>
                 <BackButton />
             </Grid>
-            <Typography variant="h5" className={classes.header}>
+            <Typography variant="h5" component="h1" className={classes.header}>
                 {props.header}
             </Typography>
             <Grid item className={classes.bodyGrid}>

--- a/src/data/calculatorPages.ts
+++ b/src/data/calculatorPages.ts
@@ -20,7 +20,7 @@ const CANT_DETERMINE_FEEDBACK_FORM_LINK =
 const data: Pages = {
     "landing-0": {
         type: PageType.MAIN,
-        header: "Eligibility Calulator",
+        header: "Eligibility Calculator",
         body: [
             {
                 type: BodyType.PARAGRAPH,

--- a/src/data/resourcesData.ts
+++ b/src/data/resourcesData.ts
@@ -116,7 +116,7 @@ const housingAdvisory: resourceLink[] = [
     },
     {
         name: "Transgender Law Center (2016)",
-        url: "hhttp://transgenderlawcenter.org/wp-content/uploads/2016/02/03.09.2016-Model-Homeless-Shelter-TG-Policy-single-pages.pdf",
+        url: "http://transgenderlawcenter.org/wp-content/uploads/2016/02/03.09.2016-Model-Homeless-Shelter-TG-Policy-single-pages.pdf",
     },
 ];
 


### PR DESCRIPTION
Shoutout to @sjpaige for the much more elegant solution to the issue. In short, the Skip Navigation Links feature wouldn't work due to not all pages having h1 elements, and Sebastian's much more elegant solution has been posted. Accessibility and simplicity in code, two birds with one stone.

Also, there was a spelling error in the Eligibility Calculator page. Title read 'Eligibility Calulator'

Also, there was a broken link on the /resources#housing page for the Housing Advisory collapsible button. The Transgender Law Center (2016) link