### PR TITLE
1811: Update EndScreen component to handle inline links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "@types/react": "^17.0.14",
                 "@types/react-dom": "^17.0.10",
                 "dotenv": "^13.0.1",
+                "prop-types": "^15.8.1",
                 "react": "^16.13.1",
                 "react-dom": "^16.13.1",
                 "react-router-dom": "^5.2.0",
@@ -4829,13 +4830,19 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001299",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
-            "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/browserslist"
-            }
+            "version": "1.0.30001387",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001387.tgz",
+            "integrity": "sha512-fKDH0F1KOJvR+mWSOvhj8lVRr/Q/mc5u5nabU2vi1/sgvlSqEsE8dOq0Hy/BqVbDkCYQPRRHB1WRjW6PGB/7PA==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                }
+            ]
         },
         "node_modules/case-sensitive-paths-webpack-plugin": {
             "version": "2.4.0",
@@ -18283,9 +18290,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001299",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
-            "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw=="
+            "version": "1.0.30001387",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001387.tgz",
+            "integrity": "sha512-fKDH0F1KOJvR+mWSOvhj8lVRr/Q/mc5u5nabU2vi1/sgvlSqEsE8dOq0Hy/BqVbDkCYQPRRHB1WRjW6PGB/7PA=="
         },
         "case-sensitive-paths-webpack-plugin": {
             "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "@types/react": "^17.0.14",
         "@types/react-dom": "^17.0.10",
         "dotenv": "^13.0.1",
+        "prop-types": "^15.8.1",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "react-router-dom": "^5.2.0",

--- a/src/Pages/Calculator/EndScreen.jsx
+++ b/src/Pages/Calculator/EndScreen.jsx
@@ -7,12 +7,13 @@ import { CVPListItem } from "../../ui-kit/ListItem";
 import { BodyType } from "../../data/calculatorPagesTypes";
 import ProgressBar from "../../Components/ProgressBar";
 import { ExternalLink } from "../../ui-kit/ExternalLink";
+import PropTypes from 'prop-types';
 
 const EndScreen = props => {
     const classes = EndScreenStyles();
 
     return (
-        <Grid container className={classes.grid}>
+        <Grid data-testid="end-screen" container className={classes.grid}>
             {props.progressBar && (
                 <Grid container>
                     <ProgressBar currentSectionName={props.currentSectionName} />
@@ -31,9 +32,9 @@ const EndScreen = props => {
                         switch (b.type) {
                             case BodyType.LIST: {
                                 return (
-                                    <ul>
-                                        {b.items.map((item, idx) => (
-                                            <li className={classes.list} key={idx}>
+                                    <ul key={idx}>
+                                        {b.items.map((item, itemIdx) => (
+                                            <li className={classes.list} key={itemIdx}>
                                                 {item}
                                             </li>
                                         ))}
@@ -54,16 +55,21 @@ const EndScreen = props => {
                                 );
                             case BodyType.LINK:
                                 return (
-                                    <ul>
+                                    <ul key={idx}>
                                         <li className={classes.list} key={idx}>
+                                            {b.textBeforeLink &&
+                                                <span>{b.textBeforeLink}</span>
+                                            }
                                             <ExternalLink
                                                 target="_blank"
                                                 rel="noopener noreferrer"
-                                                role="button"
                                                 href={b.href}
                                             >
-                                                {b.text}
+                                                {b.linkText}
                                             </ExternalLink>
+                                            {b.textAfterLink &&
+                                                <span>{b.textAfterLink}</span>
+                                            }
                                         </li>
                                     </ul>
                                 );
@@ -98,6 +104,15 @@ const EndScreen = props => {
             </Grid>
         </Grid>
     );
+};
+
+EndScreen.propTypes = {
+    header: PropTypes.string.isRequired,
+    body: PropTypes.arrayOf(PropTypes.object).isRequired,
+    buttons: PropTypes.arrayOf(PropTypes.object).isRequired,
+    disclaimer: PropTypes.string.isRequired,
+    showRestartButton: PropTypes.bool.isRequired,
+    progressBar: PropTypes.object.isRequired,
 };
 
 export default EndScreen;

--- a/src/Pages/Calculator/EndScreen.spec.js
+++ b/src/Pages/Calculator/EndScreen.spec.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import EndScreen from './EndScreen';
+import { BodyType } from "../../data/calculatorPagesTypes";
+
+describe('<EndScreen />', () => {
+    it('should render all main elements as expected when all props are passed', () => {
+        const body = [
+            {
+                type: BodyType.PARAGRAPH,
+                text: "It looks like your conviction may be eligible to vacate",
+            },
+            {
+                type: BodyType.HEADING,
+                text: "Next steps:",
+            },
+            {
+                type: BodyType.LIST,
+                items: [
+                    "list item 1",
+                    "list item 2",
+                ],
+            },
+            {
+                type: BodyType.LINK,
+                linkText: "full line link",
+                href: "www.fulllinelink.com",
+            },
+            {
+                type: BodyType.LINK,
+                textBeforeLink: 'test of inline link. ',
+                linkText: "inline link",
+                textAfterLink: " - text after link",
+                href: "www.inlinelink.com",
+            },
+        ];
+        
+        const buttons = [
+            {
+                text: 'test button',
+                href: 'test.com',
+            },
+        ];
+
+        const progressBar = {
+            currentSectionName: 'ELIGIBLE',
+        };
+
+        render(<EndScreen
+                  header={"Your Conviction May Be Eligible to Vacate!"}
+                  body={body}
+                  buttons={buttons}
+                  disclaimer={'This is the disclaimer'}
+                  showRestartButton={true}
+                  progressBar={progressBar} />,
+                { wrapper: BrowserRouter });
+
+        expect(screen.getByTestId('end-screen')).toBeVisible();
+        expect(screen.getByRole('heading', { name: 'Your Conviction May Be Eligible to Vacate!'})).toBeInTheDocument();
+
+        expect(screen.getByText('It looks like your conviction may be eligible to vacate')).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Next steps:'})).toBeInTheDocument();
+
+        const lists = screen.getAllByRole('list');
+        expect(lists.length).toBe(3);
+
+        const listItemsInList = within(lists[0]).getAllByRole('listitem');
+        expect(listItemsInList).toHaveLength(2);
+        expect(listItemsInList[0]).toHaveTextContent('list item 1');
+
+        const fullLineLink = within(lists[1]).getByRole('link');
+        expect(fullLineLink).toHaveTextContent('full line link');
+        expect(fullLineLink).toHaveAttribute('href', 'www.fulllinelink.com');
+        expect(fullLineLink).not.toHaveAttribute('role', 'button');
+
+        const inlineLinkListItem = within(lists[2]).getByRole('listitem');
+        expect(inlineLinkListItem).toHaveTextContent('test of inline link. inline link - text after link');
+
+        const inlineLink = within(inlineLinkListItem).getByRole('link');
+        expect(inlineLink).toHaveTextContent('inline link');
+        expect(inlineLink).toHaveAttribute('href', 'www.inlinelink.com');
+
+        expect(screen.getByRole('button', { name: 'test button'})).toHaveAttribute('href', 'test.com');
+        expect(screen.getByRole('link', { name: 'Check another conviction'})).toBeInTheDocument();
+        expect(screen.getByText('This is the disclaimer')).toBeInTheDocument();
+        expect(screen.getByTestId('progress-bar')).toBeInTheDocument();
+    });
+});

--- a/src/Pages/Calculator/QuestionScreen.jsx
+++ b/src/Pages/Calculator/QuestionScreen.jsx
@@ -68,7 +68,7 @@ const QuestionScreen = props => {
                                                 role="button"
                                                 href={b.href}
                                             >
-                                                {b.text}
+                                                {b.linkText}
                                             </ExternalLink>
                                         </li>
                                     </ul>

--- a/src/Pages/Calculator/SpecialCaseTitle.jsx
+++ b/src/Pages/Calculator/SpecialCaseTitle.jsx
@@ -45,7 +45,7 @@ const SpecialCaseTitle = props => {
                                                 role="link"
                                                 href={b.href}
                                             >
-                                                {b.text}
+                                                {b.linkText}
                                             </ExternalLink>
                                         </li>
                                     </ul>

--- a/src/data/calculatorPages.ts
+++ b/src/data/calculatorPages.ts
@@ -28,7 +28,7 @@ const data: Pages = {
             },
             {
                 type: BodyType.LINK,
-                text: "If you are not sure whether your conviction is a misdemeanor, request your record here",
+                linkText: "If you are not sure whether your conviction is a misdemeanor, request your record here",
                 href: "https://www.wsp.wa.gov/crime/criminal-history",
             },
         ],
@@ -385,7 +385,7 @@ const data: Pages = {
         body: [
             {
                 type: BodyType.LINK,
-                text: "A violent offense, as defined in RCW 9.94A.030",
+                linkText: "A violent offense, as defined in RCW 9.94A.030",
                 href: "https://apps.leg.wa.gov/rcw/default.aspx?cite=9.94A.030",
             },
             {
@@ -419,7 +419,7 @@ const data: Pages = {
             },
             {
                 type: BodyType.LINK,
-                text: "RCW 9.94A.030",
+                linkText: "RCW 9.94A.030",
                 href: "https://apps.leg.wa.gov/rcw/default.aspx?cite=9.94A.030",
             },
         ],
@@ -441,17 +441,17 @@ const data: Pages = {
         body: [
             {
                 type: BodyType.LINK,
-                text: "RCW 46.61.502 - driving while under the influence",
+                linkText: "RCW 46.61.502 - driving while under the influence",
                 href: "https://app.leg.wa.gov/rcw/default.aspx?cite=46.61.502",
             },
             {
                 type: BodyType.LINK,
-                text: "RCW 46.61.504 - Physical control of vehicle under the influence",
+                linkText: "RCW 46.61.504 - Physical control of vehicle under the influence",
                 href: "https://app.leg.wa.gov/rcw/default.aspx?cite=46.61.504",
             },
             {
                 type: BodyType.LINK,
-                text: "RCW 9.91.020 - operating a railroad, etc. while intoxicated",
+                linkText: "RCW 9.91.020 - operating a railroad, etc. while intoxicated",
                 href: "https://app.leg.wa.gov/rcw/default.aspx?cite=9.91.020",
             },
         ],
@@ -481,17 +481,17 @@ const data: Pages = {
             },
             {
                 type: BodyType.LINK,
-                text: "RCW 46.61.502 - driving while under the influence",
+                linkText: "RCW 46.61.502 - driving while under the influence",
                 href: "https://app.leg.wa.gov/rcw/default.aspx?cite=46.61.502",
             },
             {
                 type: BodyType.LINK,
-                text: "RCW 46.61.504 - actual physical control while under the influence",
+                linkText: "RCW 46.61.504 - actual physical control while under the influence",
                 href: "https://app.leg.wa.gov/rcw/default.aspx?cite=46.61.504",
             },
             {
                 type: BodyType.LINK,
-                text: "RCW 9.91.020 - operating a railroad, etc. while intoxicated",
+                linkText: "RCW 9.91.020 - operating a railroad, etc. while intoxicated",
                 href: "https://app.leg.wa.gov/rcw/default.aspx?cite=9.91.020",
             },
         ],
@@ -513,7 +513,7 @@ const data: Pages = {
         body: [
             {
                 type: BodyType.LINK,
-                text: "Prior offense is defined in Section 14 of RCW 46.61.5055.",
+                linkText: "Prior offense is defined in Section 14 of RCW 46.61.5055.",
                 href: "https://app.leg.wa.gov/RCW/default.aspx?cite=46.61.5055",
             },
         ],
@@ -556,17 +556,17 @@ const data: Pages = {
         body: [
             {
                 type: BodyType.LINK,
-                text: "Chapter 9.68 RCW - obscenity and pornography",
+                linkText: "Chapter 9.68 RCW - obscenity and pornography",
                 href: "https://app.leg.wa.gov/rcw/default.aspx?cite=9.68",
             },
             {
                 type: BodyType.LINK,
-                text: "Chapter 9.68A RCW - sexual exploitation of children",
+                linkText: "Chapter 9.68A RCW - sexual exploitation of children",
                 href: "https://app.leg.wa.gov/rcw/default.aspx?cite=9.68A",
             },
             {
                 type: BodyType.LINK,
-                text: "Chapter 9A.44 RCW - sex offenses, except for failure to register as a sex offender under RCW 9A.44.132",
+                linkText: "Chapter 9A.44 RCW - sex offenses, except for failure to register as a sex offender under RCW 9A.44.132",
                 href: "https://app.leg.wa.gov/rcw/default.aspx?cite=9a.44",
             },
         ],
@@ -596,17 +596,17 @@ const data: Pages = {
             },
             {
                 type: BodyType.LINK,
-                text: "Chapter 9.68 RCW - obscenity and pornography",
+                linkText: "Chapter 9.68 RCW - obscenity and pornography",
                 href: "https://app.leg.wa.gov/rcw/default.aspx?cite=9.68",
             },
             {
                 type: BodyType.LINK,
-                text: "Chapter 9.68A RCW - sexual exploitation of children",
+                linkText: "Chapter 9.68A RCW - sexual exploitation of children",
                 href: "https://app.leg.wa.gov/rcw/default.aspx?cite=9.68A",
             },
             {
                 type: BodyType.LINK,
-                text: "Chapter 9A.44 RCW - sex offenses, except for failure to register as a sex offender under RCW 9A.44.132",
+                linkText: "Chapter 9A.44 RCW - sex offenses, except for failure to register as a sex offender under RCW 9A.44.132",
                 href: "https://app.leg.wa.gov/rcw/default.aspx?cite=9a.44",
             },
         ],
@@ -695,7 +695,7 @@ const data: Pages = {
         body: [
             {
                 type: BodyType.LINK,
-                text: "Domestic Violence Information",
+                linkText: "Domestic Violence Information",
                 href: "https://www.courts.wa.gov/dv/?fa=dv.guide",
             },
         ],
@@ -897,7 +897,7 @@ const data: Pages = {
             },
             {
                 type: BodyType.LINK,
-                text: "RCW 9.96.060 (4)",
+                linkText: "RCW 9.96.060 (4)",
                 href: "https://app.leg.wa.gov/RCW/default.aspx?cite=9.96.060",
             },
             {
@@ -914,7 +914,7 @@ const data: Pages = {
             },
             {
                 type: BodyType.LINK,
-                text: "Washington Court Form",
+                linkText: "Washington Court Form",
                 href: "https://www.courts.wa.gov/forms/?fa=forms.contribute&formID=38",
             },
             {
@@ -931,7 +931,7 @@ const data: Pages = {
             },
             {
                 type: BodyType.LINK,
-                text: "Washington Law Help instructions on vacating a conviction related to Treaty Indian Fishing Rights. ",
+                linkText: "Washington Law Help instructions on vacating a conviction related to Treaty Indian Fishing Rights. ",
                 href: "https://www.washingtonlawhelp.org/files/C9D2EA3F-0350-D9AF-ACAE-BF37E9BC9FFA/attachments/D7D7897D-DE79-4E5A-B51F-B1708D37541C/8714en_vacate-a-conviction-treaty-indian-fishing-rights.pdf",
             },
         ],
@@ -1101,12 +1101,12 @@ const data: Pages = {
             },
             {
                 type: BodyType.LINK,
-                text: "RCW 9.96.060 (3)",
+                linkText: "RCW 9.96.060 (3)",
                 href: "https://apps.leg.wa.gov/rcw/default.aspx?cite=9.96.060",
             },
             {
                 type: BodyType.LINK,
-                text: " RCW 9.96.080",
+                linkText: " RCW 9.96.080",
                 href: "https://apps.leg.wa.gov/rcw/default.aspx?cite=9.96.080",
             },
             {
@@ -1123,7 +1123,7 @@ const data: Pages = {
             },
             {
                 type: BodyType.LINK,
-                text: "CrRLJ 09.0100",
+                linkText: "CrRLJ 09.0100",
                 href: "https://www.courts.wa.gov/forms/?fa=forms.contribute&formID=38",
             },
             {
@@ -1132,7 +1132,7 @@ const data: Pages = {
             },
             {
                 type: BodyType.LINK,
-                text: "CrRLJ 09.0300",
+                linkText: "CrRLJ 09.0300",
                 href: "https://www.courts.wa.gov/forms/?fa=forms.contribute&formID=38",
             },
             {
@@ -1141,7 +1141,7 @@ const data: Pages = {
             },
             {
                 type: BodyType.LINK,
-                text: "Click here.",
+                linkText: "Click here.",
                 href: "https://www.washingtonlawhelp.org/resource/get-misdemeanor-convictions-off-your-criminal-record",
             },
         ],
@@ -1517,7 +1517,7 @@ const data: Pages = {
         body: [
             {
                 type: BodyType.LINK,
-                text: "Legal financial obligations",
+                linkText: "Legal financial obligations",
                 href: "https://apps.leg.wa.gov/rcw/default.aspx?cite=9.94A.760",
             },
         ],
@@ -1550,17 +1550,21 @@ const data: Pages = {
             },
             {
                 type: BodyType.LINK,
-                text: 'Fill out a "Petition and Declaration for Order Vacating Conviction" (CrRLJ 09.0100).',
+                textBeforeLink: 'Fill out a "Petition and Declaration for Order Vacating Conviction" form: ',
+                linkText: 'CrRLJ 09.0100',
                 href: "https://www.courts.wa.gov/forms/?fa=forms.contribute&formID=38",
             },
             {
                 type: BodyType.LINK,
-                text: "Read instructions for vacating a conviction in form CrRLJ 09.0300.",
+                textBeforeLink: 'Read instructions for vacating a conviction: ',
+                linkText: 'CrRLJ 09.0300',
                 href: "https://www.courts.wa.gov/forms/?fa=forms.contribute&formID=38",
             },
             {
                 type: BodyType.LINK,
-                text: "Read more about misdemeanor conviction vacation.",
+                textBeforeLink: "Read more about misdemeanor conviction vacation ",
+                linkText: "here",
+                textAfterLink: ".",
                 href: "https://www.washingtonlawhelp.org/resource/get-misdemeanor-convictions-off-your-criminal-record",
             },
         ],

--- a/src/data/calculatorPagesTypes.ts
+++ b/src/data/calculatorPagesTypes.ts
@@ -56,7 +56,9 @@ interface ParagraphBody extends BaseBody {
 }
 
 interface LinkBody extends BaseBody {
-    text: string;
+    textBeforeLink?: string;
+    linkText: string;
+    textAfterLink?: string;
     href: string;
 }
 


### PR DESCRIPTION
This will allow a line of text to contain a link without consuming the entire line. First discovered when working on copy changes in 1776. Included new test spec for EndScreen to cover the new component API. Also updatedthe /too-eligible-0 page to use the new feature.

Also:
- Added prop-types library for component prop type checking
- Removed a browserlist error by updating the caniuse package

After:
<img width="1648" alt="after" src="https://user-images.githubusercontent.com/12855894/187817546-904cf623-14bb-483e-a13c-104d2f4d0de6.png">
