### PR TITLE
Remove broken link from main-8 calculator page.

### DIFF
--- a/src/data/calculatorPages.ts
+++ b/src/data/calculatorPages.ts
@@ -694,7 +694,6 @@ const data: Pages = {
     "main-8": {
         type: PageType.QUESTION,
         header: "Was the offense considered domestic violence against a family / household member or spouse / partner?",
-
         progressBar: {
             currentSectionName: SectionName.OFF,
         },

--- a/src/data/calculatorPages.ts
+++ b/src/data/calculatorPages.ts
@@ -693,14 +693,8 @@ const data: Pages = {
     },
     "main-8": {
         type: PageType.QUESTION,
-        header: "Was the offense considered domestic violence against family / household member or spouse / partner?",
-        body: [
-            {
-                type: BodyType.LINK,
-                linkText: "Domestic Violence Information",
-                href: "https://www.courts.wa.gov/dv/?fa=dv.guide",
-            },
-        ],
+        header: "Was the offense considered domestic violence against a family / household member or spouse / partner?",
+
         progressBar: {
             currentSectionName: SectionName.OFF,
         },


### PR DESCRIPTION
### Ticket(s)

- [Airtable Record #227](https://airtable.com/appfJZShN8K4tcWHU/tblvBIYoi6TLmdRAv/viwOGbkRnFAhe9830/recBG1KXwIXK2f2pW?blocks=hide)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

The main-8 page of the calculator contained a [link to an external page](https://www.courts.wa.gov/dv/?fa=dv.guide) that no longer exists. The link has been removed completely to avoid confusion for users.

### Screenshots

#### Before
![227-before](https://user-images.githubusercontent.com/84053550/193343988-2f5804ae-329a-49cd-9d88-cb87782d95c4.PNG)

#### After
![227-after](https://user-images.githubusercontent.com/84053550/193344004-f84bc144-4c43-444b-a8cc-a4d9bd52aad0.PNG)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings