### PR TITLE
Updated module card font style on onboarding homepage

### DIFF
--- a/src/Components/Onboarding/ModuleCard.jsx
+++ b/src/Components/Onboarding/ModuleCard.jsx
@@ -26,7 +26,9 @@ function ModuleCard(props) {
             <Link style={{ textDecoration: "none" }} to={link}>
                 <div>
                     <div className={classes.cardHeading}>
-                        <Typography variant="body1">{number}</Typography>
+                        <Typography variant="body1" className={classes.cardHeadingText}>
+                            {number}
+                        </Typography>
                     </div>
                     <div className={classes.cardBody}>
                         {number === "module 1" && <img className={classes.iconStyle} src={screens} alt="" />}

--- a/src/Styles/Onboarding/useModuleCardStyles.js
+++ b/src/Styles/Onboarding/useModuleCardStyles.js
@@ -1,4 +1,4 @@
-import { makeStyles } from '@mui/styles';
+import { makeStyles } from "@mui/styles";
 
 export const useModuleCardStyles = makeStyles(theme => ({
     moduleCard: {
@@ -11,11 +11,11 @@ export const useModuleCardStyles = makeStyles(theme => ({
             transform: "scale(1.08)",
             backgroundColor: "lightgrey",
         },
-        [theme.breakpoints.down('md')]: {
+        [theme.breakpoints.down("md")]: {
             width: "90%",
             margin: theme.spacing(2, "auto"),
         },
-        [theme.breakpoints.down('sm')]: {
+        [theme.breakpoints.down("sm")]: {
             width: "95%",
         },
     },
@@ -25,17 +25,24 @@ export const useModuleCardStyles = makeStyles(theme => ({
         color: "#f6f6f6",
         borderRadius: "20px",
         textTransform: "uppercase",
-        [theme.breakpoints.down('sm')]: {
+        [theme.breakpoints.down("sm")]: {
             display: "none",
         },
     },
+    // added a new style to change the style of specifically the text
+    cardHeadingText: {
+        fontSize: "22px",
+        fontWeight: "700",
+    },
     cardSubheading: {
         marginBottom: theme.spacing(3),
-        [theme.breakpoints.down('md')]: {
+        [theme.breakpoints.down("md")]: {
             display: "flex",
             justifyContent: "space-around",
             textAlign: "center",
         },
+        fontSize: "25px",
+        color: "#2f3554",
     },
     cardBody: {
         display: "flex",
@@ -45,25 +52,26 @@ export const useModuleCardStyles = makeStyles(theme => ({
         paddingRight: theme.spacing(3),
         paddingTop: theme.spacing(4),
         color: "#2b2929",
-        [theme.breakpoints.down('md')]: {
+        [theme.breakpoints.down("md")]: {
             display: "flex",
             flexDirection: "column",
             paddingLeft: theme.spacing(1),
             paddingRight: theme.spacing(1),
         },
-        [theme.breakpoints.down('sm')]: {
+        [theme.breakpoints.down("sm")]: {
             display: "flex",
             flexDirection: "column",
         },
     },
     cardText: {
-        [theme.breakpoints.down('md')]: {
+        [theme.breakpoints.down("md")]: {
             textAlign: "center",
         },
+        fontSize: "20px",
     },
     iconStyle: {
         marginRight: theme.spacing(4.5),
-        [theme.breakpoints.down('md')]: {
+        [theme.breakpoints.down("md")]: {
             marginRight: theme.spacing(0),
             marginBottom: theme.spacing(2),
             height: "75px",
@@ -78,7 +86,7 @@ export const useModuleCardStyles = makeStyles(theme => ({
     subheadingStyle: {
         marginBottom: theme.spacing(8),
         paddingBottom: theme.spacing(8),
-        [theme.breakpoints.down('md')]: {
+        [theme.breakpoints.down("md")]: {
             fontSize: "40px",
         },
     },


### PR DESCRIPTION
### Ticket(s)
_Required unless this is just a change to documentation._

- [Ticket Link](https://airtable.com/appfJZShN8K4tcWHU/tblXQZfKPAJIjV4cL/viwOwB82ZZJeSj1xJ/rec4yAs4D72fVFKOU?blocks=hide)

### Type of change
_Please delete any options that are not relevant_

- [ ] Bug fix (non-breaking change which fixes an issue)

### Description

Request Details:
Update Staging Onboarding Homepage to match [Figma](https://www.figma.com/file/fpTXBs2MAKO2jO2FkyCkIG/onboarding-site-cvp?node-id=462%3A2578):
Module card headings font-color - #2f3554
Module card headings: font-size: 25px;
Module Card title (ex: module 1) - font-weight: 700, size: 22px
Module Card body: font-size: 20px

Description:
- Added a new styling theme named cardHeadingText to useModuleCardStyles.js. Added fontSize and fontWeight to cardHeadingText.
- Added className={classes.cardHeadingText} to Typography component on line 29 of ModuleCard.jsx.
- Added fontSize and color to cardSubheading in useModuleCardStyles.js.
- Added fontSize to cardText in useModuleCardStyles.js.


Fixes # (issue)

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/101013004/193951162-3d58331c-cf6f-4611-993c-52b18a1e57f1.png)

#### After
![image](https://user-images.githubusercontent.com/101013004/193951219-30a9f048-43b7-44a0-a5a6-4d36c1f64eb2.png)

### Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes
