### PR TITLE
NEMO-233/broken-modal-link

### DIFF
--- a/src/Components/Onboarding/ModuleContent.jsx
+++ b/src/Components/Onboarding/ModuleContent.jsx
@@ -441,7 +441,7 @@ function ModuleContent(props) {
                     maxWidth="lg"
                     className={modalClasses.mainModal}
                 >
-                    <DialogContent sx={modalStyle}>
+                    <DialogContent>
                         <SlackModal handleSlackClose={handleSlackClose} />
                     </DialogContent>
                 </Dialog>


### PR DESCRIPTION
### Ticket(s)
- [Airtable Ticket #233](https://airtable.com/appfJZShN8K4tcWHU/tblvBIYoi6TLmdRAv/viwOGbkRnFAhe9830/recLl1m8CTDGUZ5NI?blocks=hide)

### Type of change
_Please delete any options that are not relevant_

- [ ] Bug fix (non-breaking change which fixes an issue)

### Description

The Dialog component that controls this modal contained an sx attribute that was causing the modal to not open when the screen width was >= 768px. By removing this attribute, the component is now more in line with the other buttons on the page.

I'd like to investigate a related issue a bit further. It seems there's some code here that can be cleaned up to better modularize our components, and currently the modals don't act in a responsive manner. They switch between their "mobile" and "desktop" views only if the page is refreshed at a page width below 768px, but not if the page is resized. As seen in the after image, the list text should also be adjusted. I'll create some bug reports for these issues and get working on them!

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/84053550/194802921-575179cf-4fe4-4e69-a888-8752d5b7f3ad.png)


#### After
![image](https://user-images.githubusercontent.com/84053550/194802882-9e2dc251-cf4a-457b-bdd4-12c369209b09.png)

### Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
