### PR TITLE
Nemo 234/modal responsiveness fix

### DIFF
--- a/src/Components/Onboarding/AirtableModal.jsx
+++ b/src/Components/Onboarding/AirtableModal.jsx
@@ -68,7 +68,7 @@ export default function AirtableModal(props) {
 
     return (
         <Grid container>
-            <Grid item xs={2}>
+            <Grid item xs={3}>
                 {sections.map(section => (
                     <button
                         key={section.id}
@@ -79,7 +79,7 @@ export default function AirtableModal(props) {
                     </button>
                 ))}
             </Grid>
-            <Grid item xs={7} style={contentStyle}>
+            <Grid item xs={8} style={contentStyle}>
                 {sectionId === 1 && (
                     <div>
                         <ol>

--- a/src/Components/Onboarding/ModuleCard.jsx
+++ b/src/Components/Onboarding/ModuleCard.jsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Typography, Grid } from "@mui/material";
+import { Typography } from "@mui/material";
 
 // icons
 import screens from "../../Assets/Onboarding/screens.svg";
@@ -14,12 +13,6 @@ import { useModuleCardStyles } from "../../Styles/Onboarding/useModuleCardStyles
 function ModuleCard(props) {
     const classes = useModuleCardStyles();
     const { number, link, text, subheading } = props.module;
-    const [isLargeScreen, setIsLargeScreen] = useState(true);
-
-    useEffect(() => {
-        const mediaSize = window.innerWidth;
-        mediaSize >= 768 ? setIsLargeScreen(true) : setIsLargeScreen(false);
-    }, []);
 
     return (
         <div className={classes.moduleCard}>

--- a/src/Components/Onboarding/ModuleContent.jsx
+++ b/src/Components/Onboarding/ModuleContent.jsx
@@ -8,6 +8,7 @@ import {
     ListItemIcon,
     Dialog,
     DialogContent,
+    useMediaQuery,
 } from "@mui/material";
 import { useModuleContentStyles } from "../../Styles/Onboarding/useModuleContentStyles";
 import { useModalStyles } from "../../Styles/Onboarding/useModalStyles";
@@ -27,17 +28,6 @@ import VideoTutorialAccordion from "./Mobile/VideoTutorialAccordion";
 import SlackVideoAccordion from "./Mobile/SlackVideoAccordion";
 import TrustDocAccordion from "./Mobile/TrustDocAccordion";
 import { ExternalLink } from "../../ui-kit/ExternalLink";
-
-const modalStyle = {
-    position: "absolute",
-    top: "50%",
-    left: "50%",
-    transform: "translate(-50%, -50%)",
-    width: "80%",
-    bgcolor: "background.paper",
-    boxShadow: 24,
-    padding: "50px",
-};
 
 function ModuleContent(props) {
     const classes = useModuleContentStyles();
@@ -109,12 +99,7 @@ function ModuleContent(props) {
     const handleFindVideoOpen = () => setFindVideoOpen(true);
     const handleFindVideoClose = () => setFindVideoOpen(false);
 
-    const [isLargeScreen, setIsLargeScreen] = useState(true);
-
-    useEffect(() => {
-        const mediaSize = window.innerWidth;
-        mediaSize >= 768 ? setIsLargeScreen(true) : setIsLargeScreen(false);
-    }, []);
+    const isLargeScreen = useMediaQuery('(min-width:850px)');
 
     return (
         <div className={classes.moduleContentCard}>

--- a/src/Components/Onboarding/ModuleStepper.jsx
+++ b/src/Components/Onboarding/ModuleStepper.jsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect } from "react";
 // components
 import ModuleCard from "./ModuleCard";
-import { Grid } from "@mui/material";
+import { Grid, useMediaQuery } from "@mui/material";
 
 // icons
 import circleCheck from "../../Assets/Onboarding/circleCheck.png";
@@ -46,12 +45,9 @@ const styles = {
 
 export default function VerticalLinearStepper() {
     const classes = useHomeStyles();
-    const [isLargeScreen, setIsLargeScreen] = useState(true);
 
-    useEffect(() => {
-        const mediaSize = window.innerWidth;
-        mediaSize >= 768 ? setIsLargeScreen(true) : setIsLargeScreen(false);
-    }, []);
+    const isLargeScreen = useMediaQuery('(min-width:600px)');
+
 
     return (
         <>

--- a/src/Components/Onboarding/SlackModal.jsx
+++ b/src/Components/Onboarding/SlackModal.jsx
@@ -60,7 +60,7 @@ export default function SlackModal(props) {
 
     return (
         <Grid container>
-            <Grid item xs={2}>
+            <Grid item xs={3}>
                 {sections.map(section => (
                     <button
                         key={section.id}
@@ -71,7 +71,7 @@ export default function SlackModal(props) {
                     </button>
                 ))}
             </Grid>
-            <Grid item xs={7} style={contentStyle}>
+            <Grid item xs={8} style={contentStyle}>
                 {sectionId === 1 && (
                     <div>
                         <ol>


### PR DESCRIPTION
### Ticket(s)
[Airtable Ticket #234](https://airtable.com/appfJZShN8K4tcWHU/tblvBIYoi6TLmdRAv/viwu0dTfy2Nj0A4PZ/recGGg3hsTL6iShsU?blocks=hide)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

### Description

Fixed the responsiveness of the complex onboarding modals. I also made this change for the stepper on the module selection page. The change isn't perfect, as it still involves hardcoding the value for the useMediaQuery hook to use. A long-term goal may be to go through and make sure all of our responsive code uses the same methods and components are better broken down.

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/84053550/195159990-dd1120a8-11c8-4b22-abb3-cf296bcbc626.png)

Stepper should disappear after resizing below a given breakpoint
![image](https://user-images.githubusercontent.com/84053550/195160295-cb097f0d-8e3c-4b21-b06f-09b240a7e097.png)


#### After
Switches to accordion modal style responsively when window width < 850px.
![image](https://user-images.githubusercontent.com/84053550/195160132-45cb16aa-a1dd-44ff-afe7-8bcc8c46f1fa.png)
Switches to sidebar modal style responsively when window width >= 850px.
![image](https://user-images.githubusercontent.com/84053550/195160178-174ba052-dffb-4f15-8bb8-91b671f3918f.png)
Stepper now disappears when resizing window width < 600px.
![image](https://user-images.githubusercontent.com/84053550/195160438-4308e871-cbf5-4376-bf43-7243fc90ac04.png)



### Checklist:

- [ ] I have performed a self-review of my own code
