### PR TITLE
Change RedesignButton components to styled API for proposed migration.

### DIFF
--- a/src/Components/ImageContentCard.jsx
+++ b/src/Components/ImageContentCard.jsx
@@ -1,6 +1,7 @@
 import { Paper, Typography, Box } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { RedesignButtonPrimary } from "../ui-kit/RedesignButtonPrimary";
+import { RedesignButtonSecondary } from "../ui-kit/RedesignButtonSecondary";
 
 const useStyles = makeStyles(theme => ({
     rootStyle: {

--- a/src/Components/Navigation.jsx
+++ b/src/Components/Navigation.jsx
@@ -20,6 +20,7 @@ import LegalDisclaimer from "./LegalDisclaimer";
 import NavigationLogo from "./NavigationLogo";
 import SkipLink from "../ui-kit/SkipLink";
 import { RedesignButtonPrimary } from "../ui-kit/RedesignButtonPrimary";
+import { RedesignButtonSecondary } from "../ui-kit/RedesignButtonSecondary";
 
 const useStyles = makeStyles(theme => ({
     closeIcon: {
@@ -51,19 +52,6 @@ const useStyles = makeStyles(theme => ({
             transform: "translateX(0)",
         },
     },
-    navCalc: {
-        height: "3rem",
-        textAlign: "center",
-        fontSize: "1rem",
-        borderRadius: "50px",
-        padding: "1rem",
-        backgroundColor: "white",
-        color: theme.palette.primary.dark,
-        "&:hover": {
-            backgroundColor: theme.palette.secondary.main,
-            color: theme.palette.secondary.contrastText,
-        },
-    },
 }));
 
 const Navigation = () => {
@@ -84,7 +72,7 @@ const Navigation = () => {
                 <Container maxWidth="xl">
                     <Toolbar>
                         <SkipLink className={classes.skipLink}>
-                            <Button style={{ color: "white" }}>Skip Navigation Links</Button>
+                            <Button>Skip Navigation Links</Button>
                         </SkipLink>
                         <NavigationLogo />
                         <Box style={{ flexGrow: 1 }} />
@@ -96,9 +84,9 @@ const Navigation = () => {
                                     page.key !== PageId.AccessCalculator ? <NavButton key={idx} page={page} /> : null
                                 )}
                             </ButtonGroup>
-                            <RedesignButtonPrimary href="/calculator/landing-0" className={classes.navCalc}>
+                            <RedesignButtonSecondary href="/calculator/landing-0">
                                 Access Calculator
-                            </RedesignButtonPrimary>
+                            </RedesignButtonSecondary>
                         </Box>
                         {/* mobile menu */}
 

--- a/src/Pages/HomePage.jsx
+++ b/src/Pages/HomePage.jsx
@@ -37,9 +37,12 @@ const HomePage = () => {
                                 conviction for free in less than 10 minutes!
                             </Typography>
                             <Box paddingTop={12}>
-                                <RedesignButtonSecondary href="/calculator/landing-0" sx={{
-                                    width: '100%'
-                                }}>
+                                <RedesignButtonSecondary
+                                    href="/calculator/landing-0"
+                                    sx={{
+                                        width: "100%",
+                                    }}
+                                >
                                     Access Calculator
                                 </RedesignButtonSecondary>
                             </Box>
@@ -144,7 +147,14 @@ const HomePage = () => {
                             <Typography variant="h3" className={classes.headingStyle}>
                                 Help us improve the calculator by participating in research
                             </Typography>
-                            <RedesignButtonSecondary href="https://docs.google.com/forms/d/1KXmPrwzHeE8_EEL88RFkjOFP4S1A52Ode1vV6SJijao/viewform?edit_requested=true">
+                            <RedesignButtonSecondary
+                                href="https://docs.google.com/forms/d/1KXmPrwzHeE8_EEL88RFkjOFP4S1A52Ode1vV6SJijao/viewform?edit_requested=true"
+                                sx={theme => ({
+                                    "&:hover": {
+                                        backgroundColor: theme.palette.primary.dark,
+                                    },
+                                })}
+                            >
                                 Learn more
                             </RedesignButtonSecondary>
                         </Grid>

--- a/src/Pages/HomePage.jsx
+++ b/src/Pages/HomePage.jsx
@@ -37,9 +37,11 @@ const HomePage = () => {
                                 conviction for free in less than 10 minutes!
                             </Typography>
                             <Box paddingTop={12}>
-                                <RedesignButtonPrimary href="/calculator/landing-0" className={classes.calcHome}>
+                                <RedesignButtonSecondary href="/calculator/landing-0" sx={{
+                                    width: '100%'
+                                }}>
                                     Access Calculator
-                                </RedesignButtonPrimary>
+                                </RedesignButtonSecondary>
                             </Box>
                         </Grid>
                         <Grid item xs={12} sm={6}>

--- a/src/ui-kit/RedesignButtonPrimary.jsx
+++ b/src/ui-kit/RedesignButtonPrimary.jsx
@@ -1,31 +1,15 @@
 import { Button } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { styled } from "@mui/material/styles";
 
-const useStyles = makeStyles(theme => ({
-    RedesignButtonPrimaryStyle: {
-        width: "248px",
-        height: "48px",
-        borderRadius: "50px",
-        padding: "16px",
-        "&:hover": {
-            backgroundColor: theme.palette.secondary.main,
-            color: theme.palette.secondary.contrastText,
-        },
+// Uses styled() instead of makeStyles()
+export const RedesignButtonPrimary = styled(Button)(({ theme }) => ({
+    width: 248,
+    height: 48,
+    borderRadius: 50,
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+    "&:hover": {
+        backgroundColor: theme.palette.secondary.main,
+        color: theme.palette.secondary.contrastText,
     },
 }));
-
-export const RedesignButtonPrimary = props => {
-    const classes = useStyles();
-
-    return (
-        <Button
-            className={classes.RedesignButtonPrimaryStyle}
-            role="button"
-            variant="contained"
-            color="primary"
-            {...props}
-        >
-            {props.children}
-        </Button>
-    );
-};

--- a/src/ui-kit/RedesignButtonSecondary.jsx
+++ b/src/ui-kit/RedesignButtonSecondary.jsx
@@ -1,32 +1,15 @@
 import { Button } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { styled } from "@mui/material/styles";
 
-const useStyles = makeStyles(theme => ({
-    RedesignButtonSecondaryStyle: {
-        width: "248px",
-        height: "48px",
-        borderRadius: "50px",
-        padding: "16px",
-        backgroundColor: theme.palette.primary.light,
-        color: theme.palette.secondary.contrastText,
-        "&:hover": {
-            backgroundColor: theme.palette.secondary,
-            color: theme.palette.secondary.contrastText,
-        },
+// Uses styled() instead of makeStyles()
+export const RedesignButtonSecondary = styled(Button)(({ theme }) => ({
+    width: 248,
+    height: 48,
+    borderRadius: 50,
+    backgroundColor: "white",
+    color: theme.palette.primary.dark,
+    "&:hover": {
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.primary.contrastText,
     },
 }));
-
-export const RedesignButtonSecondary = props => {
-    const classes = useStyles();
-
-    return (
-        <Button
-            className={`${classes.RedesignButtonSecondaryStyle} ${props.classes}`}
-            role="button"
-            variant="contained"
-            {...props}
-        >
-            {props.children}
-        </Button>
-    );
-};


### PR DESCRIPTION
### Type of change
-   [x] Migration Proposal

### Description

We currently use the makeStyles() API for the bulk of our styling. It seems that MUI is pushing for users to migrate to the styled/sx solution provided by the default Emotions styling engine.

Migrating the entire application would probably take quite a bit of time, and to be honest I'm not sure what the ramifications of doing so would be. As a tiny proof-of-concept, I've migrated the Primary and Secondary button components to the proposed format.

### Screenshots

![image](https://user-images.githubusercontent.com/84053550/199088285-073a3b38-d91b-465f-b51d-9d91409f2ffd.png)

![image](https://user-images.githubusercontent.com/84053550/199088493-dbe776a2-d429-48a2-9a11-25f90fff1df8.png)

In the above screenshots, we have a few buttons which use the RedesignButtonPrimary and RedesignButtonSecondary components. Ideally, I think we should be able to match up our UI kit with Design's kit in Figma. That capability should be provided by the styled() API. From what I understand, styled() simply extends the base MUI component, so we can use the `sx` prop in our custom components to override or extend styles, which is seemingly not possible with the makeStyle() way of doing things. This helps to easily create responsive components or make simple overrides, such as setting the width of the Home Page Hero CTA to 100%.

Hopefully, the result is that it's easier to stick to a unified design both while maintaining and adding to the site!

### Checklist:

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation (if applicable)
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
-   [x] New and existing unit tests pass locally with my changes
