### PR TITLE
Givingtuesday donate link change

### DIFF
--- a/src/Pages/DonatePage.jsx
+++ b/src/Pages/DonatePage.jsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import { Box, Container, Grid, Typography } from "@mui/material";
 
 import laptop from "../Assets/laptop.svg";
@@ -11,7 +9,6 @@ import searchEngineer from "../Assets/search_enginer.svg";
 
 import DonateFAQAccordion from "../Subpages/GetInvolved/DonateFAQAccordion";
 import DonateLevelCard from "../Components/DonateLevelCard";
-import DonateDialog from "../Components/DonateDialog";
 import { RedesignButtonPrimary } from "../ui-kit/RedesignButtonPrimary";
 import { useGetInvolvedStyles } from "../Styles/useGetInvolvedStyles";
 
@@ -51,15 +48,6 @@ const donationLevels = [
 ];
 
 const DonatePage = ({ title, md }) => {
-    const [open, setOpen] = useState(false);
-
-    const handleClickOpen = () => {
-        setOpen(true);
-    };
-
-    const handleClose = () => {
-        setOpen(false);
-    };
     const classes = useGetInvolvedStyles();
     return (
         <>
@@ -97,7 +85,6 @@ const DonatePage = ({ title, md }) => {
                 <RedesignButtonPrimary href="https://donorbox.org/clearviction-givingtuesday">
                     donate
                 </RedesignButtonPrimary>
-                {/* <DonateDialog open={open} onClose={handleClose} /> */}
             </Container>
 
             <Container className={classes.regularContainerStyle} maxWidth="md">

--- a/src/Pages/DonatePage.jsx
+++ b/src/Pages/DonatePage.jsx
@@ -94,8 +94,10 @@ const DonatePage = ({ title, md }) => {
             </Container>
 
             <Container className={classes.CTAButtonContainerStyle}>
-                <RedesignButtonPrimary onClick={handleClickOpen}>donate</RedesignButtonPrimary>
-                <DonateDialog open={open} onClose={handleClose} />
+                <RedesignButtonPrimary href="https://donorbox.org/clearviction-givingtuesday">
+                    donate
+                </RedesignButtonPrimary>
+                {/* <DonateDialog open={open} onClose={handleClose} /> */}
             </Container>
 
             <Container className={classes.regularContainerStyle} maxWidth="md">


### PR DESCRIPTION
### Type of change

Button functionality change.

### Description

Changed the "Donate" button on the main donation page (and by extension, the GivingTuesday page) to be a direct link to the [Cleaviction GivingTuesday fundraising page hosted by Donorbox](https://donorbox.org/clearviction-givingtuesday). This gives people a direct way to donate and a potentially more social-media-friendly way to spread the word. When the GivingTuesday campaign ends, we will probably need to change this link to match a new, more long-term campaign.

From a UX/transparency standpoint, it may be helpful to reimplement the dialog box that this replaces, but as a "You are about to navigate to..." notification for the user. 

### Checklist:

-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation (if applicable)
-   [ ] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
-   [ ] New and existing unit tests pass locally with my changes
