### PR TITLE
Remove reference to GT on homepage

### DIFF
--- a/src/Pages/HomePage.jsx
+++ b/src/Pages/HomePage.jsx
@@ -26,31 +26,6 @@ const HomePage = () => {
         <>
             <Box className={classes.darkBlueBackground}>
                 <Container maxWidth="lg">
-                    <Box
-                        sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            flexDirection: { xs: "column", md: "row" },
-                        }}
-                    >
-                        <Box mb={{ xs: 2, md: 0 }} mr={{ xs: 0, md: 8 }}>
-                            <Typography variant="h2" color="secondary.light" fontWeight="700">
-                                #GivingTuesday
-                            </Typography>
-                            <Typography variant="subtitle1" sx={{ fontSize: 16, lineHeight: "2em" }} textAlign="center">
-                                November 29, 2022
-                            </Typography>
-                        </Box>
-                        <Button
-                            sx={{ width: "fit-content", paddingX: 4 }}
-                            variant="contained"
-                            color="primary"
-                            href="/givingtuesday"
-                        >
-                            Donate Now
-                        </Button>
-                    </Box>
-
                     <Typography className={classes.headingStyle} variant="h1">
                         Washington's Vacation Eligibility Calculator
                     </Typography>

--- a/src/data/siteMap.ts
+++ b/src/data/siteMap.ts
@@ -18,7 +18,6 @@ interface Page {
 
 const headerPages: Page[] = [
     { name: "Home", url: "/", key: PageId.Home },
-    { name: "Giving Tuesday", url: "/givingtuesday", key: PageId.GivingTuesday },
     { name: "Get Started", url: "/get-started", key: PageId.GetStarted },
     { name: "Get Involved", url: "/get-involved", key: PageId.GetInvolved },
     { name: "Why Vacate", url: "/why-vacate", key: PageId.WhyVacate },


### PR DESCRIPTION
### Type of change

_Please delete any options that are not relevant_

-   [ ] Bug fix (non-breaking change which fixes an issue)
(Not really a bug, but kinda)

### Description

Removed references to Giving Tuesday campaign on the homepage. Hero and navigation bar

Fixes # (issue)
- GT is over, staying up to date.
### Screenshots

#### Before
<img width="1657" alt="Screen Shot 2022-12-04 at 10 58 20 AM" src="https://user-images.githubusercontent.com/59981297/205504577-e73b5a49-13ea-4b98-a450-554dbc931a07.png">

#### After
<img width="1649" alt="Screen Shot 2022-12-04 at 10 58 09 AM" src="https://user-images.githubusercontent.com/59981297/205504568-a70167e2-082f-4ec8-97f8-4dff11ec9daf.png">

### Checklist:

-   [x] I have performed a self-review of my own code
-   [ x] I have commented my code, particularly in hard-to-understand areas
-   [ x] I have made corresponding changes to the documentation (if applicable)
-   [ x] My changes generate no new warnings
-   [ x] New and existing unit tests pass locally with my changes

